### PR TITLE
feat(terraform): persistent workspace for long-term backup buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,13 +328,11 @@ terraform plan  # should show no changes, or minor drift to reconcile
 
 ### Adding a new game
 
-Add an entry to `local.longterm_buckets` in `terraform/persistent/main.tf`:
+Add the game name to `var.games` in `terraform/persistent/variables.tf`. The bucket name is derived automatically as `{game}-long-term-backups`.
 
 ```hcl
-longterm_buckets = {
-  valheim      = "valheim-long-term-backups"
-  satisfactory = "satisfactory-long-term-backups"
-  newgame      = "newgame-long-term-backups"
+variable "games" {
+  default = ["valheim", "satisfactory", "newgame"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -305,27 +305,6 @@ Save files for each game are stored in dedicated long-term S3 buckets that persi
 
 These buckets are managed by the `terraform/persistent/` workspace — **separate from the per-game stacks** — so they survive `terraform destroy` on a game server. Versioning is enabled with a 90-day noncurrent version retention policy.
 
-### Initial Setup (import existing buckets)
-
-If the buckets already exist (created manually), import them into Terraform state:
-
-```bash
-cd terraform/persistent
-terraform init
-
-terraform import 'aws_s3_bucket.longterm["valheim"]' valheim-long-term-backups
-terraform import 'aws_s3_bucket.longterm["satisfactory"]' satisfactory-long-term-backups
-
-terraform import 'aws_s3_bucket_versioning.longterm["valheim"]' valheim-long-term-backups
-terraform import 'aws_s3_bucket_versioning.longterm["satisfactory"]' satisfactory-long-term-backups
-
-# Only if lifecycle rules were previously configured on the buckets:
-terraform import 'aws_s3_bucket_lifecycle_configuration.longterm["valheim"]' valheim-long-term-backups
-terraform import 'aws_s3_bucket_lifecycle_configuration.longterm["satisfactory"]' satisfactory-long-term-backups
-
-terraform plan  # should show no changes, or minor drift to reconcile
-```
-
 ### Adding a new game
 
 Add the game name to `var.games` in `terraform/persistent/variables.tf`. The bucket name is derived automatically as `{game}-long-term-backups`.

--- a/README.md
+++ b/README.md
@@ -296,6 +296,48 @@ aws cloudtrail start-logging --name management-events
 
 Once CloudTrail is enabled, the EventBridge rules will automatically start capturing game server state changes.
 
+## Long-Term Backups
+
+Save files for each game are stored in dedicated long-term S3 buckets that persist independently of game server infrastructure:
+
+- `valheim-long-term-backups`
+- `satisfactory-long-term-backups`
+
+These buckets are managed by the `terraform/persistent/` workspace — **separate from the per-game stacks** — so they survive `terraform destroy` on a game server. Versioning is enabled with a 90-day noncurrent version retention policy.
+
+### Initial Setup (import existing buckets)
+
+If the buckets already exist (created manually), import them into Terraform state:
+
+```bash
+cd terraform/persistent
+terraform init
+
+terraform import 'aws_s3_bucket.longterm["valheim"]' valheim-long-term-backups
+terraform import 'aws_s3_bucket.longterm["satisfactory"]' satisfactory-long-term-backups
+
+terraform import 'aws_s3_bucket_versioning.longterm["valheim"]' valheim-long-term-backups
+terraform import 'aws_s3_bucket_versioning.longterm["satisfactory"]' satisfactory-long-term-backups
+
+# Only if lifecycle rules were previously configured on the buckets:
+terraform import 'aws_s3_bucket_lifecycle_configuration.longterm["valheim"]' valheim-long-term-backups
+terraform import 'aws_s3_bucket_lifecycle_configuration.longterm["satisfactory"]' satisfactory-long-term-backups
+
+terraform plan  # should show no changes, or minor drift to reconcile
+```
+
+### Adding a new game
+
+Add an entry to `local.longterm_buckets` in `terraform/persistent/main.tf`:
+
+```hcl
+longterm_buckets = {
+  valheim      = "valheim-long-term-backups"
+  satisfactory = "satisfactory-long-term-backups"
+  newgame      = "newgame-long-term-backups"
+}
+```
+
 ## Clean Up
 
 To remove all resources:
@@ -303,3 +345,5 @@ To remove all resources:
 ```bash
 terraform destroy
 ```
+
+**Note:** `terraform destroy` in a game workspace (`terraform/games/<game>/`) does **not** affect the long-term backup buckets. To manage those, use the `terraform/persistent/` workspace explicitly.

--- a/terraform/persistent/backend.tf
+++ b/terraform/persistent/backend.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket  = "valheim-ec2-tf-state"
+    key     = "bonfire/persistent/terraform.tfstate"
+    region  = "eu-north-1"
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/persistent/main.tf
+++ b/terraform/persistent/main.tf
@@ -4,27 +4,22 @@ locals {
     ManagedBy = "terraform"
     Purpose   = "longterm-backups"
   }
-
-  longterm_buckets = {
-    valheim      = "valheim-long-term-backups"
-    satisfactory = "satisfactory-long-term-backups"
-  }
 }
 
 resource "aws_s3_bucket" "longterm" {
-  for_each = local.longterm_buckets
+  for_each = toset(var.games)
 
-  bucket        = each.value
+  bucket        = "${each.key}-long-term-backups"
   force_destroy = false
 
   tags = merge(local.tags, {
-    Name = each.value
+    Name = "${each.key}-long-term-backups"
     Game = each.key
   })
 }
 
 resource "aws_s3_bucket_versioning" "longterm" {
-  for_each = local.longterm_buckets
+  for_each = toset(var.games)
 
   bucket = aws_s3_bucket.longterm[each.key].id
 
@@ -34,7 +29,7 @@ resource "aws_s3_bucket_versioning" "longterm" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "longterm" {
-  for_each = local.longterm_buckets
+  for_each = toset(var.games)
 
   bucket = aws_s3_bucket.longterm[each.key].id
 

--- a/terraform/persistent/main.tf
+++ b/terraform/persistent/main.tf
@@ -1,0 +1,53 @@
+locals {
+  tags = {
+    Project   = "bonfire"
+    ManagedBy = "terraform"
+    Purpose   = "longterm-backups"
+  }
+
+  longterm_buckets = {
+    valheim      = "valheim-long-term-backups"
+    satisfactory = "satisfactory-long-term-backups"
+  }
+}
+
+resource "aws_s3_bucket" "longterm" {
+  for_each = local.longterm_buckets
+
+  bucket        = each.value
+  force_destroy = false
+
+  tags = merge(local.tags, {
+    Name = each.value
+    Game = each.key
+  })
+}
+
+resource "aws_s3_bucket_versioning" "longterm" {
+  for_each = local.longterm_buckets
+
+  bucket = aws_s3_bucket.longterm[each.key].id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "longterm" {
+  for_each = local.longterm_buckets
+
+  bucket = aws_s3_bucket.longterm[each.key].id
+
+  rule {
+    id     = "retain-noncurrent-versions"
+    status = "Enabled"
+
+    filter {
+      prefix = ""
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.longterm_version_retention_days
+    }
+  }
+}

--- a/terraform/persistent/main.tf
+++ b/terraform/persistent/main.tf
@@ -9,8 +9,11 @@ locals {
 resource "aws_s3_bucket" "longterm" {
   for_each = toset(var.games)
 
-  bucket        = "${each.key}-long-term-backups"
-  force_destroy = false
+  bucket = "${each.key}-long-term-backups"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 
   tags = merge(local.tags, {
     Name = "${each.key}-long-term-backups"

--- a/terraform/persistent/outputs.tf
+++ b/terraform/persistent/outputs.tf
@@ -1,0 +1,9 @@
+output "longterm_bucket_names" {
+  description = "Long-term backup bucket names by game"
+  value       = { for k, v in aws_s3_bucket.longterm : k => v.bucket }
+}
+
+output "longterm_bucket_arns" {
+  description = "Long-term backup bucket ARNs by game"
+  value       = { for k, v in aws_s3_bucket.longterm : k => v.arn }
+}

--- a/terraform/persistent/variables.tf
+++ b/terraform/persistent/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-north-1"
+}
+
+variable "longterm_version_retention_days" {
+  description = "Number of days to retain noncurrent versions in long-term buckets"
+  type        = number
+  default     = 90
+}

--- a/terraform/persistent/variables.tf
+++ b/terraform/persistent/variables.tf
@@ -4,6 +4,12 @@ variable "aws_region" {
   default     = "eu-north-1"
 }
 
+variable "games" {
+  description = "List of games to create long-term backup buckets for. Bucket name is derived as {game}-long-term-backups."
+  type        = list(string)
+  default     = ["valheim", "satisfactory"]
+}
+
 variable "longterm_version_retention_days" {
   description = "Number of days to retain noncurrent versions in long-term buckets"
   type        = number


### PR DESCRIPTION
## Summary

- Adds `terraform/persistent/` — a new Terraform workspace independent of any game stack
- Manages `valheim-long-term-backups` and `satisfactory-long-term-backups` S3 buckets
- Versioning enabled; noncurrent versions retained for 90 days (vs 7 days for game-attached backup buckets)
- State stored at `bonfire/persistent/terraform.tfstate` in the existing state bucket

## Why separate workspace

The long-term buckets must survive game stack destroy/reprovision cycles. Keeping them in `terraform/games/<game>/` would risk catching them in a `terraform destroy`.

## Import steps (run once after merge)

```bash
cd terraform/persistent
terraform init

terraform import 'aws_s3_bucket.longterm["valheim"]' valheim-long-term-backups
terraform import 'aws_s3_bucket.longterm["satisfactory"]' satisfactory-long-term-backups

terraform import 'aws_s3_bucket_versioning.longterm["valheim"]' valheim-long-term-backups
terraform import 'aws_s3_bucket_versioning.longterm["satisfactory"]' satisfactory-long-term-backups

# Only if lifecycle rules were previously configured on the buckets:
terraform import 'aws_s3_bucket_lifecycle_configuration.longterm["valheim"]' valheim-long-term-backups
terraform import 'aws_s3_bucket_lifecycle_configuration.longterm["satisfactory"]' satisfactory-long-term-backups

terraform plan  # should show no changes, or minor drift to reconcile
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)