### PR TITLE
fix(bot): Line layout — v1.5 shape + "lit" label rename

### DIFF
--- a/discord_bot/go/embeds.go
+++ b/discord_bot/go/embeds.go
@@ -28,14 +28,18 @@ const (
 const (
 	// Idempotent Line copy (type 4, flags 64) — see plan § Idempotency.
 	// Each includes the `● <label>` state-pill dot per brand Line format.
-	copyStartAlreadyRunning    = "fire's already ● burning · lit %s ago · %s"
-	copyStartAlreadyRunningWithBackup = "fire's already ● burning · lit %s ago · %s · backup %s ago"
-	copyStartAlreadyLighting   = "fire's already ● lighting · started %s ago · ~2 min total"
-	copyStartWhileStopping     = "hang on — someone's ● banking the coals · try again in a minute"
-	copyStopAlreadyOut         = "fire's already ● out · last burned %s ago"
-	copyStopAlreadyOutNever    = "fire's already ● out · never burned"
-	copyStopAlreadyDyingDown   = "fire's already ● dying down · saving the world"
-	copyStopWhilePending       = "can't bank coals yet · fire's still ● lighting · try again in a minute"
+	// Running-state shape follows BRAND.md v1.5 Line spec:
+	//   `<wrapper> · ● lit · <addr> · <uptime> · backup <X> ago`
+	// (no "lit X ago" clause — uptime is bare, per brand v1.5 Line example).
+	// Param order: addr, uptime (+ backup).
+	copyStartAlreadyRunning           = "fire's already ● lit · %s · %s"                     // addr, uptime
+	copyStartAlreadyRunningWithBackup = "fire's already ● lit · %s · %s · backup %s ago"     // addr, uptime, backup
+	copyStartAlreadyLighting          = "fire's already ● lighting · lit %s ago · ~2 min total" // elapsed — "lit X ago" per v1.5 starting-state copy shape
+	copyStartWhileStopping            = "hang on — someone's ● banking the coals · try again in a minute"
+	copyStopAlreadyOut                = "fire's already ● out · last burned %s ago"
+	copyStopAlreadyOutNever           = "fire's already ● out · never burned"
+	copyStopAlreadyDyingDown          = "fire's already ● dying down · saving the world"
+	copyStopWhilePending              = "can't bank coals yet · fire's still ● lighting · try again in a minute"
 
 	// Polling in-flight / terminal Hero bodies.
 	copyLightingBody         = "lighting the fire… (%s)"
@@ -51,10 +55,12 @@ const (
 	copyFooterLitBy    = "lit by %s"
 	copyFooterPutOutBy = "put out by %s"
 
-	// /status Line one-liners — `<Game> · ● <label> · ...` per BRAND.md §"Line".
-	copyStatusRunning         = "%s · ● burning · %s · %s · backup %s ago"
-	copyStatusRunningNoBackup = "%s · ● burning · %s · %s · never burned"
-	copyStatusPending         = "%s · ● lighting · started %s ago · ~2 min total"
+	// /status Line one-liners — `<Game> · ● <label> · ...` per BRAND.md v1.5 §"Line".
+	// Running: `<Game> · ● lit · <addr> · <uptime> · backup <X> ago`.
+	// Pending: `<Game> · ● lighting · lit <X> ago · ~2 min total` (v1.5 "lit X ago" idiom).
+	copyStatusRunning         = "%s · ● lit · %s · %s · backup %s ago"          // game, addr, uptime, backup
+	copyStatusRunningNoBackup = "%s · ● lit · %s · %s · never burned"           // game, addr, uptime
+	copyStatusPending         = "%s · ● lighting · lit %s ago · ~2 min total"   // game, elapsed
 	copyStatusStopping        = "%s · ● dying down · saving the world"
 	copyStatusStopped         = "%s · ● out · last burned %s ago"
 	copyStatusStoppedNever    = "%s · ● out · never burned"

--- a/discord_bot/go/main.go
+++ b/discord_bot/go/main.go
@@ -529,17 +529,17 @@ func handleStartCommand(
 	// Idempotency: state ∈ {running, pending, stopping} → ephemeral Line, no start, no self-invoke.
 	switch info.State {
 	case "running":
-		elapsed := formatElapsed(elapsedSince(info.LaunchTime))
-		// Include backup trailer when we have one — the running Line format is
-		// `... lit X ago · addr · backup Y ago` per BRAND.md §"Line".
+		uptime := formatElapsed(elapsedSince(info.LaunchTime))
+		// Include backup trailer when we have one — v1.5 Line format is
+		// `<wrapper> · ● lit · <addr> · <uptime> · backup <X> ago`.
 		backup := ""
 		if s3Client != nil {
 			backup = backupElapsedString(ctx, s3Client, gameName, awsRegion(), "[ack] ")
 		}
 		if backup != "" {
-			return ephemeralEmbedResponse(lineEmbed("running", fmt.Sprintf(copyStartAlreadyRunningWithBackup, elapsed, info.PublicIP, backup)))
+			return ephemeralEmbedResponse(lineEmbed("running", fmt.Sprintf(copyStartAlreadyRunningWithBackup, info.PublicIP, uptime, backup)))
 		}
-		return ephemeralEmbedResponse(lineEmbed("running", fmt.Sprintf(copyStartAlreadyRunning, elapsed, info.PublicIP)))
+		return ephemeralEmbedResponse(lineEmbed("running", fmt.Sprintf(copyStartAlreadyRunning, info.PublicIP, uptime)))
 	case "pending":
 		elapsed := formatElapsed(elapsedSince(info.LaunchTime))
 		return ephemeralEmbedResponse(lineEmbed("pending", fmt.Sprintf(copyStartAlreadyLighting, elapsed)))

--- a/discord_bot/go/main_test.go
+++ b/discord_bot/go/main_test.go
@@ -698,12 +698,14 @@ func TestHandleInteraction_StatusRunning(t *testing.T) {
 
 	ir := parseInteractionResponse(t, resp)
 	embed := firstEmbed(t, ir)
-	// /status Line copy still uses the pre-v1.5 "burning" literal in the
-	// current body shape (`%s · ● burning · ...`). The state-label rename
-	// in v1.5 (burning → lit) applies to Hero embeds; Line-layout copy is
-	// deferred for a separate review pass (user decision 2026-04-19).
-	if !strings.Contains(embedBody(embed), "burning") {
-		t.Errorf("expected 'burning' in /status Line body, got: %s", embedBody(embed))
+	// v1.5 Line format: `<Game> · ● lit · <addr> · <uptime> · backup <X> ago`.
+	// Label rename (burning → lit) and shape alignment with BRAND.md v1.5
+	// §"Line" landed together in the Line-pass PR.
+	if !strings.Contains(embedBody(embed), "● lit") {
+		t.Errorf("expected '● lit' state dot + label in /status Line body, got: %s", embedBody(embed))
+	}
+	if strings.Contains(embedBody(embed), "burning") {
+		t.Errorf("v1.5: Line should not contain 'burning' anymore, got: %s", embedBody(embed))
 	}
 	if !strings.Contains(embedBody(embed), "1.2.3.4") {
 		t.Errorf("expected IP address in status, got: %s", embedBody(embed))
@@ -757,8 +759,8 @@ func TestHandleInteraction_StartAuthorized_AlreadyRunning(t *testing.T) {
 
 	ir := parseInteractionResponse(t, resp)
 	embed := firstEmbed(t, ir)
-	if !strings.Contains(embedBody(embed), "fire's already ● burning") {
-		t.Errorf("expected 'fire's already ● burning' idempotency copy, got: %s", embedBody(embed))
+	if !strings.Contains(embedBody(embed), "fire's already ● lit") {
+		t.Errorf("expected 'fire's already ● lit' idempotency copy, got: %s", embedBody(embed))
 	}
 	if !strings.Contains(embedBody(embed), "5.6.7.8") {
 		t.Errorf("expected bare address in body, got: %s", embedBody(embed))
@@ -1810,10 +1812,82 @@ func TestBackupElapsedString_NoDoubleAgo(t *testing.T) {
 	if strings.Contains(got, "ago") {
 		t.Errorf("helper output should not contain 'ago' anymore, got %q", got)
 	}
-	// And the /start-already-burning idempotency Line (once formatted with this helper's output)
-	// should read "backup 10h 45m ago" — not "backup 10h 45m ago ago".
-	composed := fmt.Sprintf(copyStartAlreadyRunningWithBackup, "30s", "1.2.3.4", got)
+	// And the /start-already-lit idempotency Line (once formatted with this helper's output)
+	// should read "backup 10h 45m ago" — not "backup 10h 45m ago ago". v1.5 param
+	// order: addr, uptime, backup.
+	composed := fmt.Sprintf(copyStartAlreadyRunningWithBackup, "1.2.3.4", "30s", got)
 	if strings.Contains(composed, "ago ago") {
 		t.Errorf("composed Line body contains 'ago ago' — the double-ago bug is back: %q", composed)
+	}
+}
+
+// --- BRAND v1.5 Line-pass: shape + label alignment ---
+
+func TestStatusRunning_v1_5_Shape(t *testing.T) {
+	// /status running Line should read: `<Game> · ● lit · <addr> · <uptime> · backup <X> ago`
+	// per BRAND.md v1.5 §"Line". No "burning" literal anywhere.
+	ssmClient := ssmWithGuild("g1")
+	mock := &mockEC2Client{describeOutput: runningInstanceWithID("i-test", "51.20.112.157")}
+	resp := runHandle(context.Background(), interactionWith("valheim", "status", "", "g1"), mock, ssmClient)
+	ir := parseInteractionResponse(t, resp)
+	body := embedBody(firstEmbed(t, ir))
+
+	if !strings.Contains(body, "● lit ·") {
+		t.Errorf("expected '● lit ·' dot+label in v1.5 Line, got: %s", body)
+	}
+	if !strings.Contains(body, "51.20.112.157") {
+		t.Errorf("expected bare address in v1.5 Line, got: %s", body)
+	}
+	if strings.Contains(body, "burning") {
+		t.Errorf("v1.5 Line should not contain 'burning' anymore, got: %s", body)
+	}
+	// Order check: address before "never burned" / "backup X ago" trailer.
+	lit := strings.Index(body, "● lit")
+	addr := strings.Index(body, "51.20.112.157")
+	if lit < 0 || addr < 0 || addr < lit {
+		t.Errorf("expected '● lit' before address, got: %s", body)
+	}
+}
+
+func TestStartAlreadyRunning_v1_5_Shape(t *testing.T) {
+	// Idempotent /start-while-running shape: `fire's already ● lit · <addr> · <uptime>`
+	// (+ `· backup <X> ago` when backup present). No "lit <X> ago · <addr>" ordering —
+	// that was the v1.4 shape and produced awkward double-"lit" after the label rename.
+	ssmClient := ssmWithGuildAndUsers("g1", "mc", "admin")
+	mock := &mockEC2Client{describeOutput: runningInstanceWithID("i-test", "5.6.7.8")}
+	resp := runHandle(context.Background(), interactionWith("mc", "start", "admin", "g1"), mock, ssmClient)
+	body := embedBody(firstEmbed(t, parseInteractionResponse(t, resp)))
+
+	if !strings.Contains(body, "fire's already ● lit ·") {
+		t.Errorf("expected 'fire's already ● lit · ' prefix, got: %s", body)
+	}
+	if strings.Contains(body, "burning") {
+		t.Errorf("v1.5 idempotency Line should not say 'burning', got: %s", body)
+	}
+	// The order must be addr before uptime (matches brand Line shape).
+	litPill := strings.Index(body, "● lit")
+	addr := strings.Index(body, "5.6.7.8")
+	if litPill < 0 || addr < 0 || addr < litPill {
+		t.Errorf("expected addr after '● lit', got: %s", body)
+	}
+}
+
+func TestStatusPending_v1_5_Uses_LitXAgo(t *testing.T) {
+	// v1.5 pending copy shape: `<Game> · ● lighting · lit <X> ago · ~2 min total`.
+	// Replaces v1.4's "started <X> ago" phrasing with "lit <X> ago" per BRAND.md
+	// v1.5 starting-state copy shape.
+	ssmClient := ssmWithGuild("g1")
+	mock := &mockEC2Client{describeOutput: pendingInstanceWithID("i-test")}
+	resp := runHandle(context.Background(), interactionWith("valheim", "status", "", "g1"), mock, ssmClient)
+	body := embedBody(firstEmbed(t, parseInteractionResponse(t, resp)))
+
+	if !strings.Contains(body, "● lighting") {
+		t.Errorf("expected '● lighting' in pending status, got: %s", body)
+	}
+	if !strings.Contains(body, "lit ") || !strings.Contains(body, "ago") {
+		t.Errorf("expected 'lit <X> ago' idiom in pending status, got: %s", body)
+	}
+	if strings.Contains(body, "started") {
+		t.Errorf("v1.5: pending copy should not say 'started' anymore, got: %s", body)
 	}
 }


### PR DESCRIPTION
## Summary

Completes the v1.5 brand rollout. PR #9 (Hero pass) deferred the Line-layout copy, producing a temporary `Hero says "lit" / /status Line says "burning"` cross-surface inconsistency. This PR lands the Line-layout update so every running-state surface speaks the same v1.5 language.

BRAND.md v1.5 §"Line" exemplar:
```
Valheim · ● lit · 13.48.12.34:2456 · 1h 42m · backup 15m ago
```

**Changes:**

1. Label rename `burning` → `lit` in `/status` and idempotency Line copy (4 constants).

2. Running-state idempotency Line shape simplified. v1.4 wrapped uptime in a `lit <X> ago · <addr>` clause which collides with the `● lit` pill after the rename (double-"lit"). v1.5 drops the wrapper; uses bare `<addr> · <uptime>`:
   ```
   before: fire's already ● burning · lit 1h 42m ago · 1.2.3.4
   after:  fire's already ● lit · 1.2.3.4 · 1h 42m
   ```
   Handler Sprintf param order swapped (`addr, uptime, [backup]`). Variable renamed `elapsed` → `uptime` in the running branch for semantic clarity.

3. Pending-state idiom `started <X> ago` → `lit <X> ago` per BRAND.md v1.5 starting-state copy shape (`tending to it · lit 34s ago · usually ~2 min`). Applied to `copyStatusPending` and `copyStartAlreadyLighting`.

4. Comments on copy constants updated with v1.5 shape specs next to the format strings.

**Out of scope (documented):**
- BRAND.md's Line exemplar shows `<addr>:<port>` while `info.PublicIP` renders bare IP. UX flagged for a future ticket (same behavior as pre-PR).
- Stopping/stopped Line copy unchanged — v1.5 didn't touch those states.

## Governance

UX Reviewer Board pass on Opus: **SHIP**. Non-blocking minor (dead `for ... range` loop in a new test — refactor leftover) removed in this commit.

Cross-surface consistency window from PR #9 is now closed: grep for `burning` across `discord_bot/go/` returns only rejection assertions in tests.

## Test plan

- [x] `go build ./...` — green
- [x] `go test -count=1 ./...` — ~37 tests pass, 3 new ones pinning v1.5 Line behavior (`TestStatusRunning_v1_5_Shape`, `TestStartAlreadyRunning_v1_5_Shape`, `TestStatusPending_v1_5_Uses_LitXAgo`)
- No infra delta — `terraform validate` unchanged from PR #9.
- [ ] Post-merge live smoke: `/factorio status` on running server — expect `factorio · ● lit · <addr> · <uptime> · backup <X> ago`. `/factorio start` on running server — expect `fire's already ● lit · <addr> · <uptime>` (+ backup trailer if present). `/factorio status` on pending server — expect `● lighting · lit <X> ago · ~2 min total`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)